### PR TITLE
Add `tini` as init system to improve signal handlers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN python3 -m PyInstaller -F --strip webchanges.py
 FROM alpine:${alpine_version} as deploy
 ENV APP_USER webchanges
 ENV PYTHONUTF8=1
+RUN apk add --no-cache tini
 
 COPY --from=builder /webchanges/dist/webchanges /usr/local/bin/webchanges
 
@@ -78,4 +79,5 @@ RUN rm /var/spool/cron/crontabs/root
 COPY crontabfile ./crontabfile
 COPY run.sh ./run.sh
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/bin/sh", "run.sh"]


### PR DESCRIPTION
So far, there was no init system and `SIGTERM` was likely trapped somewhere at the shell level which started `crond` in the foreground. The consequence was that while stopping the container, nothing signaled `docker` that the process successful finished and docker waited the default 10 seconds before it killed the container.

Fixes https://github.com/yubiuser/webchanges-docker/issues/2

Now, the container stops really fast

```
chrko@ThinkPad-X230:~/Software/github/webchanges-docker$ docker compose down
[+] Running 2/2
 ✔ Container webchanges                  Removed                                                                                                                         0.2s 
 ✔ Network webchanges-docker_webchanges  Removed                                                                                                                         0.4s 
```