### PR TITLE
Add "--clean-database" to crontab file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ docker logs --follow webchanges
 For running every hour instead of the default 15 minutes, change `crontab` as following:
 
 ```crontab
-0 * * * * cd /data/webchanges && webchanges --urls jobs.yaml --config config.yaml --cache cache.db
+0 * * * * cd /data/webchanges && webchanges --urls jobs.yaml --config config.yaml --cache cache.db --clean-database
 ```
 
 Addtionally, each day at 08:00 `webchanges --error` runs to check the jobs for errors or empty data.
 
-Tip: use [crontabguru](https://crontab.guru/) to change the cron intervals. 
+Tip: use [crontabguru](https://crontab.guru/) to change the cron intervals.
 
 Mount `crontab` into the container:
 

--- a/crontabfile
+++ b/crontabfile
@@ -1,2 +1,2 @@
-*/15 * * * * date && echo "Running webchanges" && cd /data/webchanges && webchanges --urls jobs.yaml --config config.yaml --database snapshots.db
+*/15 * * * * date && echo "Running webchanges" && cd /data/webchanges && webchanges --urls jobs.yaml --config config.yaml --database snapshots.db --clean-database
 0 8 * * * date && echo "Checking webchanges jobs for errors" && cd /data/webchanges && webchanges --errors email --urls jobs.yaml --config config.yaml --database snapshots.db


### PR DESCRIPTION
I did notice that my snapshots database file grew to several hundred megabytes by now (I have > 60 jobs).
This PR adds "`--clean-database`" to `crontab` file to avoid an ever-growing snapshot database.

Quoting [the `webchanges` documentation](https://webchanges.readthedocs.io/en/stable/cli.html#compact-the-database):

![image](https://github.com/user-attachments/assets/d28fb2c7-abd9-4504-9899-60a142ab5787)

I decided to opt for `clean-database` in favor of `gc-database` to not loose the latest snapshots of jobs you have temporarily disabled, e.g., because a website is under maintenance and you have commented out the job in between to avoid errors being reported.